### PR TITLE
postgres: Use "psql -c" instead of a command from stdin

### DIFF
--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -21,29 +21,29 @@ include_recipe 'postgresql::server'
 
 execute 'postgres[user]' do
   user 'postgres'
-  command "echo 'CREATE ROLE #{node['postgres']['user']} WITH LOGIN;' | psql"
+  command "psql -c 'CREATE ROLE #{node['postgres']['user']} WITH LOGIN;'"
   not_if  "echo 'SELECT 1 FROM pg_roles WHERE rolname = \'#{node['postgres']['user']}\';' | psql | grep -q 1"
 end
 
 execute 'postgres[database]' do
   user 'postgres'
-  command "echo 'CREATE DATABASE #{node['postgres']['database']};' | psql"
+  command "psql -c 'CREATE DATABASE #{node['postgres']['database']};'"
   not_if  "echo 'SELECT 1 FROM pg_database WHERE datname = \'#{node['postgres']['database']}\';' | psql | grep -q 1"
 end
 
 execute 'postgres[privileges]' do
   user 'postgres'
-  command "echo 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA #{node['postgres']['database']} TO #{node['postgres']['user']};' | psql"
+  command "psql -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA #{node['postgres']['database']} TO #{node['postgres']['user']};'"
 end
 
 execute 'postgres[extensions][plpgsql]' do
   user 'postgres'
-  command "echo 'CREATE EXTENSION IF NOT EXISTS plpgsql' | psql"
+  command "psql -c 'CREATE EXTENSION IF NOT EXISTS plpgsql'"
   not_if "echo '\dx' | psql #{node['postgres']['database']} | grep plpgsql"
 end
 
 execute 'postgres[extensions][pg_trgm]' do
   user 'postgres'
-  command "echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql"
+  command "psql -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm'"
   not_if "echo '\dx' | psql #{node['postgres']['database']} | grep pg_trgm"
 end


### PR DESCRIPTION
Currently in `_posgres.rb` recipe we have an exit code equals 0 even if SQL command has been failed:
```bash
$ echo 'CREATE EXTENSION IF NOT EXISTS pg_trgm' | psql
ERROR:  could not open extension control file "/usr/pgsql-9.3/share/extension/pg_trgm.control": No such file or directory
$ echo $?
0
```
Due to this issue, `execute` resources never fail and we don't suspect that something goes wrong. In the example above it causes that text search is not working on Supermarket overall.

So, STDIN approach should be replaced with `psql -c`:
```bash
$ psql -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm'
ERROR:  could not open extension control file "/usr/pgsql-9.3/share/extension/pg_trgm.control": No such file or directory
$ echo $?
1
```
After that we will get an expected error in `execute` resources.
