### PR TITLE
Install "postgresql-contrib" package in order to use "pg_trgm" extension

### DIFF
--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe 'postgresql::server'
+include_recipe 'postgresql::contrib'
 
 execute 'postgres[user]' do
   user 'postgres'


### PR DESCRIPTION
See error examples from PR #84 
`pg_trgm.so` library are distributed in `postgresql-contrib` package. It is actual for CentOS 6,7 and Ubuntu distributions as well.

Following the [postgresql](https://github.com/hw-cookbooks/postgresql) cookbook description, we should just include `postgresql::contrib` recipe.
Otherwise, "pg_trgm" extension will not be installed and a text search will not be available on the Supermarket site.