### PR TITLE
Fixed attributes: 'postgres' -> 'postgresql'

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 default['postgres']['user'] = 'supermarket'
 default['postgres']['database'] = 'supermarket_production'
-default['postgresql']['version'] = '9.1'
+default['postgresql']['version'] = '9.3'
 
 default['redis']['maxmemory'] = '64mb'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,7 @@
 
 default['postgres']['user'] = 'supermarket'
 default['postgres']['database'] = 'supermarket_production'
-default['postgres']['auth_method'] = 'peer'
-default['postgres']['version'] = '9.1'
+default['postgresql']['version'] = '9.1'
 
 default['redis']['maxmemory'] = '64mb'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,7 +20,7 @@ recipe 'supermarket::vagrant',
        'Installs Supermarket and all dependencies for development'
 
 provides 'service[nginx]'
-provides 'service[postgres]'
+provides 'service[postgresql]'
 provides 'service[redis-server]'
 provides 'service[unicorn]'
 
@@ -36,10 +36,10 @@ attribute 'postgres/database',
           :type         => 'string',
           :default      => 'supermarket_production'
 
-attribute 'postgres/auth_method',
-          :display_name => 'PostgreSQL authentication method',
+attribute 'postgresql/version',
+          :display_name => 'PostgreSQL server version',
           :type         => 'string',
-          :default      => 'peer'
+          :default      => '9.1'
 
 grouping 'redis', :title => 'Redis server options'
 


### PR DESCRIPTION
Actually, [postgresql](https://github.com/hw-cookbooks/postgresql) cookbook doesn't support any ['postgres'] attributes. The correct notation is: ['postgresql']. So that:
- `['postgres']['auth_method']` can be deleted as unused. 
- `['postgres']['version']` should be renamed to `['postgresql']['version']`
- In metadata.rb `service[postgres]` should be replaced with `service[postgresql]`