### PR TITLE
Fixed PostgreSQL recipe

### DIFF
--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -34,7 +34,7 @@ end
 
 execute 'postgres[privileges]' do
   user 'postgres'
-  command "psql -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA #{node['postgres']['database']} TO #{node['postgres']['user']};'"
+  command "psql -c 'GRANT ALL ON DATABASE #{node['postgres']['database']} TO #{node['postgres']['user']};'"
 end
 
 execute 'postgres[extensions][plpgsql]' do

--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -23,13 +23,13 @@ include_recipe 'postgresql::contrib'
 execute 'postgres[user]' do
   user 'postgres'
   command "psql -c 'CREATE ROLE #{node['postgres']['user']} WITH LOGIN;'"
-  not_if  "echo 'SELECT 1 FROM pg_roles WHERE rolname = \'#{node['postgres']['user']}\';' | psql | grep -q 1"
+  not_if  "psql -c \"SELECT 1 FROM pg_roles WHERE rolname = \'#{node['postgres']['user']}\';\" | grep -q 1"
 end
 
 execute 'postgres[database]' do
   user 'postgres'
   command "psql -c 'CREATE DATABASE #{node['postgres']['database']};'"
-  not_if  "echo 'SELECT 1 FROM pg_database WHERE datname = \'#{node['postgres']['database']}\';' | psql | grep -q 1"
+  not_if  "psql -c \"SELECT 1 FROM pg_database WHERE datname = \'#{node['postgres']['database']}\';\" | grep -q 1"
 end
 
 execute 'postgres[privileges]' do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -6,8 +6,8 @@ describe 'supermarket::default' do
 
     stub_command('test -f /etc/apt/sources.list.d/chris-lea-node_js-precise.list').and_return(false)
     stub_command('test -f /etc/apt/sources.list.d/brightbox-ruby-ng-experimental-precise.list -o -f /etc/apt/sources.list.d/brightbox-ruby-ng-experimental-trusty.list').and_return(false)
-    stub_command("echo 'SELECT 1 FROM pg_roles WHERE rolname = 'supermarket';' | psql | grep -q 1").and_return(false)
-    stub_command("echo 'SELECT 1 FROM pg_database WHERE datname = 'supermarket_production';' | psql | grep -q 1").and_return(false)
+    stub_command("psql -c \"SELECT 1 FROM pg_roles WHERE rolname = 'supermarket';\" | grep -q 1").and_return(false)
+    stub_command("psql -c \"SELECT 1 FROM pg_database WHERE datname = 'supermarket_production';\" | grep -q 1").and_return(false)
     stub_command('test -f /etc/apt/sources.list.d/chris-lea-redis-server-precise.list').and_return(false)
     stub_command('test -f /etc/apt/sources.list.d/brightbox-ruby-ng-experimental-precise.list').and_return(false)
     stub_command('ruby -v | grep 2.1.3').and_return(false)


### PR DESCRIPTION
It fixes https://github.com/chef/supermarket/issues/1011

After #84 has been merged, all psql failures became visible and now we got that `_postgresql.rb` recipe had some issues for a long time. So, I fixed them:

**1)** Two `not_if` guards have single quotes inside the query. So, we can not use single quotes for the query string itself. Look how it is:
```bash
$ echo 'SELECT 1 FROM pg_roles WHERE rolname = 'supermarket';' | psql
ERROR:  column "supermarket" does not exist
LINE 1: SELECT 1 FROM pg_roles WHERE rolname = supermarket;
                                               ^
```
and how it should be:
```bash
$ psql -c "SELECT 1 FROM pg_roles WHERE rolname = 'supermarket';"
 ?column?
----------
        1
```

**2)** Invalid query for schema which does not exists:
```
       ---- Begin output of psql -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA supermarket_production TO supermarket;' ----
       STDOUT:
       STDERR: ERROR:  schema "supermarket_production" does not exist
```
Actually, we don't have a query `CREATE SCHEMA` or something like this. I think that `GRANT ALL ON DATABASE` is expected here.

/cc: @kirtfitzpatrick 