### PR TITLE
Fixed compatibility with RHEL/CentOS 6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,7 +36,5 @@ suites:
     run_list:
       - recipe[supermarket::default]
     attributes:
-      postgres:
-        auth_method: trust
       nginx:
         default_site_enabled: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,9 @@ platforms:
   - name: centos-6.5
     run_list:
       - recipe[yum]
+    attributes:
+      postgresql:
+        enable_pgdg_yum: true
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -5,6 +5,9 @@ metadata
 # Depend on version of packagecloud cookbook with matchers
 cookbook 'packagecloud', git: 'https://github.com/computology/packagecloud-cookbook.git'
 
+# Depend on the postgresql cookbook version without derived attributes
+cookbook 'postgresql', git: 'https://github.com/hw-cookbooks/postgresql', tag: 'v3.4.16'
+
 group :integration do
   cookbook 'supermarket_instance_test', path: 'test/fixtures/cookbooks/supermarket_instance_test'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,10 @@ default['postgres']['user'] = 'supermarket'
 default['postgres']['database'] = 'supermarket_production'
 default['postgresql']['version'] = '9.3'
 
+if node['platform_family'] == 'rhel'
+  default['postgresql']['enable_pgdg_yum'] = true
+end
+
 default['redis']['maxmemory'] = '64mb'
 
 default['supermarket']['home'] = '/srv/supermarket'

--- a/metadata.rb
+++ b/metadata.rb
@@ -39,7 +39,7 @@ attribute 'postgres/database',
 attribute 'postgresql/version',
           :display_name => 'PostgreSQL server version',
           :type         => 'string',
-          :default      => '9.1'
+          :default      => '9.3'
 
 grouping 'redis', :title => 'Redis server options'
 

--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -93,6 +93,14 @@ deploy_revision node['supermarket']['home'] do
       variables(app: app)
     end
 
+    execute 'bundle config for pg' do
+      cwd release_path
+      user 'supermarket'
+      group 'supermarket'
+      command "bundle config --local build.pg --with-pg-config=/usr/pgsql-#{node['postgresql']['version']}/bin/pg_config"
+      only_if { node['platform_family'] == 'rhel' && node['postgresql']['enable_pgdg_yum'] }
+    end
+
     execute 'bundle install' do
       cwd release_path
       user 'supermarket'


### PR DESCRIPTION
1) `['postgresql']['enable_pgdg_yum']` should be set to `true`, because official RHEL/CentOS repos don't contain PostgreSQL 9.x packages

2) Since PostgreSQL is installed from PGDG repo, the "pg_config" binary is not available in "$PATH" (rpm bug?). So, we need to perform a `bundle config` to guarantee that `pg` gem will be installed without errors.

3) Depend cookbook `postgresql` should be constrained to the version `3.4.16`, because other versions are affected by the issues of derived attributes (details: https://github.com/hw-cookbooks/postgresql/pull/231#issuecomment-83054583)

I also thought about specifying this constraint in the "metadata.rb", but I afraid that it could cause a dependency hell for many users of supermarket cookbook. Authors - what do you think about it?

4) Minor fixes for attributes info in "metadata.rb" and ".kitchen.yml"

P.s. In pair with #89 this PR makes integration tests pass on the CentOS 6.5 & 6.6
cc:\  @nshemonsky @jtimberman @smith 