### PR TITLE
Remove duplication in kitchen and add enable pgdg to 1204.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
-  - name: opscode-centos-6.5
+  - name: centos-6.5
     run_list:
       - recipe[yum]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,15 +20,9 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
-    attributes:
-      postgres:
-        version: "9.3"
-  - name: centos-6.5
+  - name: opscode-centos-6.5
     run_list:
       - recipe[yum]
-    attributes:
-      postgresql:
-        enable_pgdg_yum: true
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,12 +22,12 @@ default['postgres']['database'] = 'supermarket_production'
 default['postgresql']['version'] = '9.3'
 
 case node['platform_family']
-  when 'debian'
-    if node['platform_version'] == '12.04'
-      default['postgresql']['enable_pgdg_apt'] = true
-    end
-  when 'rhel'
-    default['postgresql']['enable_pgdg_yum'] = true
+when 'debian'
+  if node['platform_version'] == '12.04'
+    default['postgresql']['enable_pgdg_apt'] = true
+  end
+when 'rhel'
+  default['postgresql']['enable_pgdg_yum'] = true
 end
 
 default['redis']['maxmemory'] = '64mb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,8 +21,13 @@ default['postgres']['user'] = 'supermarket'
 default['postgres']['database'] = 'supermarket_production'
 default['postgresql']['version'] = '9.3'
 
-if node['platform_family'] == 'rhel'
-  default['postgresql']['enable_pgdg_yum'] = true
+case node['platform_family']
+  when 'debian'
+    if node['platform_version'] == '12.04'
+      default['postgresql']['enable_pgdg_apt'] = true
+    end
+  when 'rhel'
+    default['postgresql']['enable_pgdg_yum'] = true
 end
 
 default['redis']['maxmemory'] = '64mb'


### PR DESCRIPTION
PR(#86) set the default postgresql to 9.3 which does not exist
by default in the ubuntu-12.04 repos. I added the enable_pgdg_apt
option by default for 12.04.

I also removed unnecessary attribute overrides in the kitchen file
since the options are set in the default attributes.