### PR TITLE
Fixed supermarket_instance required attribute error message

### DIFF
--- a/libraries/provider_supermarket_instance.rb
+++ b/libraries/provider_supermarket_instance.rb
@@ -35,7 +35,7 @@ class Chef
 
         ['chef_server_url', 'chef_oauth2_app_id', 'chef_oauth2_secret'].each do |required|
           unless config[required]
-            raise '#{required} is a required attribute'
+            raise "#{required} is a required attribute"
           end
         end
 


### PR DESCRIPTION
The actual attribute in cause was not display correctly due to the wrong usage of single quotes.