### PR TITLE
Fixed postgres recipe guards

### DIFF
--- a/recipes/_postgres.rb
+++ b/recipes/_postgres.rb
@@ -23,13 +23,13 @@ include_recipe 'postgresql::contrib'
 execute 'postgres[user]' do
   user 'postgres'
   command "psql -c 'CREATE ROLE #{node['postgres']['user']} WITH LOGIN;'"
-  not_if  "psql -c \"SELECT 1 FROM pg_roles WHERE rolname = \'#{node['postgres']['user']}\';\" | grep -q 1"
+  not_if  "psql -c \"SELECT 1 FROM pg_roles WHERE rolname = \'#{node['postgres']['user']}\';\" | grep -q 1", :user => 'postgres'
 end
 
 execute 'postgres[database]' do
   user 'postgres'
   command "psql -c 'CREATE DATABASE #{node['postgres']['database']};'"
-  not_if  "psql -c \"SELECT 1 FROM pg_database WHERE datname = \'#{node['postgres']['database']}\';\" | grep -q 1"
+  not_if  "psql -c \"SELECT 1 FROM pg_database WHERE datname = \'#{node['postgres']['database']}\';\" | grep -q 1", :user => 'postgres'
 end
 
 execute 'postgres[privileges]' do
@@ -40,11 +40,11 @@ end
 execute 'postgres[extensions][plpgsql]' do
   user 'postgres'
   command "psql -c 'CREATE EXTENSION IF NOT EXISTS plpgsql'"
-  not_if "echo '\dx' | psql #{node['postgres']['database']} | grep plpgsql"
+  not_if "echo '\dx' | psql #{node['postgres']['database']} | grep plpgsql", :user => 'postgres'
 end
 
 execute 'postgres[extensions][pg_trgm]' do
   user 'postgres'
   command "psql -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm'"
-  not_if "echo '\dx' | psql #{node['postgres']['database']} | grep pg_trgm"
+  not_if "echo '\dx' | psql #{node['postgres']['database']} | grep pg_trgm", :user => 'postgres'
 end


### PR DESCRIPTION
The guards in `_postgres` recipe must be run as the `postgres` user unless what, the guards always exit with an error code because the user `root` does not have authorization to access the `postgres` instance by default.