### PR TITLE
Removed references to _git recipe

### DIFF
--- a/recipes/vagrant.rb
+++ b/recipes/vagrant.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'supermarket::_postgres'
 include_recipe 'supermarket::_redis'
-include_recipe 'supermarket::_git'
+include_recipe 'git'
 include_recipe 'supermarket::_ruby'
 
 execute 'dotenv[setup]' do

--- a/recipes/web.rb
+++ b/recipes/web.rb
@@ -18,7 +18,7 @@
 #
 
 include_recipe 'supermarket::_sidekiq'
-include_recipe 'supermarket::_git'
+include_recipe 'git'
 include_recipe 'supermarket::_ruby'
 include_recipe 'supermarket::_nginx'
 include_recipe 'supermarket::_runit'


### PR DESCRIPTION
It looks like the _git recipe was removed and the reference corrected in the default recipe, but the "vagrant" and "web" recipes still refer to `supermarket::_git` instead of just `git`.

Created issue here, in Supermarket repo:
https://github.com/chef/supermarket/issues/1025