### PR TITLE
Updating test-kitchen centos from 6.5 to 6.6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
-  - name: centos-6.5
+  - name: centos-6.6
     run_list:
       - recipe[yum]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v3.2.1 (2015-04-22)
+-------------------
+- [#94] Remove references to \_git recipe
+- [#93] Use correct user in PostgreSQL recipe guards
+- [#92] Fix double quotes in required attributes error message
+- [#91] Enable pgdg Apt repo; remove duplicate kitchen attributes
+
 v3.2.0 (2015-04-17)
 -------------------
 - [#90] Fix compatibility with RHEL/CentOS 6

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '3.2.0'
+version '3.2.1'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache v2.0'


### PR DESCRIPTION
6.5 is getting long in the tooth and boxes for it are no longer readily
available