### PR TITLE
Use the chef_vault_item helper, which allows fallback to JSON files

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license 'Apache v2.0'
 description 'Stands up the Supermarket application stack'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-%w(yum apt build-essential python nodejs postgresql redisio git nginx runit rubies packagecloud).each do |dep|
+%w(yum apt build-essential chef-vault python nodejs postgresql redisio git nginx runit rubies packagecloud).each do |dep|
   depends dep
 end
 

--- a/recipes/_application.rb
+++ b/recipes/_application.rb
@@ -37,9 +37,8 @@ directory "#{node['supermarket']['home']}/shared/bundle" do
 end
 
 if node['supermarket']['chef_vault']
-  chef_gem 'chef-vault'
-  require 'chef-vault'
-  app = ChefVault::Item.load(:apps, node['supermarket']['data_bag'])
+  include_recipe 'chef-vault'
+  app = chef_vault_item(:apps, node['supermarket']['data_bag'])
 else
   app = data_bag_item(:apps, node['supermarket']['data_bag'])
 end


### PR DESCRIPTION
Use the chef_vault_item helper, which allows fallback to JSON files when the vault cannot be decrypted (i.e. when under test in test-kitchen).

There isn't a TK suite for chef-vault usage, but I have tested this with a wrapper cookbook that uses the chef-vault-testfixtures gem to stub vault access during chefspec runs.  I can add that to this PR if desired, though it will double the number of TK profiles.
